### PR TITLE
Upgrade to Swift 6 and remove deprecated dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,10 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
+      - name: Update flake to latest nixpkgs
+        run: |
+          nix flake update
+
       - name: Build project
         id: build
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,19 +1,24 @@
-name: Build
+name: Build and Test
 
 on:
   push:
     branches:
       - master
+      - main
+      - swift-61
+      - 'claude/**'
   pull_request:
     branches:
       - master
+      - main
+      - swift-61
 
 concurrency:
   group: ${{ github.workflow }}-$${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:
-  build:
+  build-and-test:
     runs-on: ubuntu-latest
     permissions: write-all
 
@@ -25,7 +30,12 @@ jobs:
       - uses: DeterminateSystems/nix-installer-action@main
       - uses: DeterminateSystems/magic-nix-cache-action@main
 
-      - name: Run build
+      - name: Build project
         id: build
         run: |
           nix build
+
+      - name: Run tests
+        id: test
+        run: |
+          nix develop --command make test

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -1,0 +1,44 @@
+name: Swift CI (Docker)
+
+on:
+  push:
+    branches:
+      - master
+      - main
+      - swift-61
+      - 'claude/**'
+  pull_request:
+    branches:
+      - master
+      - main
+      - swift-61
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+
+    container:
+      image: swift:6.1
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install system dependencies
+        run: |
+          apt-get update && apt-get install -y \
+            libgd-dev \
+            libiptcdata0-dev \
+            libexif-dev \
+            pkg-config
+
+      - name: Build project
+        run: |
+          swift build
+
+      - name: Run tests
+        run: |
+          swift test

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -38,6 +38,7 @@ jobs:
             libgd-dev \
             libiptcdata0-dev \
             libexif-dev \
+            libvips-dev \
             pkg-config
 
       - name: Verify Swift installation

--- a/.github/workflows/swift-ci.yml
+++ b/.github/workflows/swift-ci.yml
@@ -1,4 +1,4 @@
-name: Swift CI (Docker)
+name: Swift CI
 
 on:
   push:
@@ -19,21 +19,30 @@ concurrency:
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
-
-    container:
-      image: swift:6.1
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v3
 
+      - name: Install Swift 6.1.2
+        run: |
+          # Download Swift 6.1.2 for Ubuntu 24.04
+          wget -q https://download.swift.org/swift-6.1.2-release/ubuntu2404/swift-6.1.2-RELEASE/swift-6.1.2-RELEASE-ubuntu24.04.tar.gz
+          tar xzf swift-6.1.2-RELEASE-ubuntu24.04.tar.gz
+          sudo mv swift-6.1.2-RELEASE-ubuntu24.04 /opt/swift
+          echo "/opt/swift/usr/bin" >> $GITHUB_PATH
+
       - name: Install system dependencies
         run: |
-          apt-get update && apt-get install -y \
+          sudo apt-get update && sudo apt-get install -y \
             libgd-dev \
             libiptcdata0-dev \
             libexif-dev \
             pkg-config
+
+      - name: Verify Swift installation
+        run: |
+          swift --version
 
       - name: Build project
         run: |

--- a/MUNIN_MODERNISE_PLAN.md
+++ b/MUNIN_MODERNISE_PLAN.md
@@ -44,7 +44,6 @@ This document outlines the comprehensive plan to modernize the Munin static gall
 - [x] ✅ **Performance**: Maintain or improve performance
 
 ### Stretch Goals
-- [ ] **Static Binary**: Enable static Swift binary compilation
 - [ ] **Documentation**: Improve code documentation
 - [ ] **CI/CD**: Add Linux-specific CI workflows
 
@@ -173,20 +172,6 @@ This document outlines the comprehensive plan to modernize the Munin static gall
   - [x] Test memory usage
   - [x] Verify concurrent processing efficiency
 
-### Phase 9: Static Binary Support (Stretch)
-- [ ] **Static Linking Research**
-  - [ ] Investigate Swift static binary requirements
-  - [ ] Test C library static linking
-  - [ ] Resolve any compatibility issues
-- [ ] **Build Configuration**
-  - [ ] Add static build flags
-  - [ ] Update Package.swift for static builds
-  - [ ] Test static binary functionality
-- [ ] **Distribution**
-  - [ ] Create static binary build scripts
-  - [ ] Test deployment scenarios
-  - [ ] Document static build process
-
 ## Risk Assessment
 
 ### High Risk Items
@@ -208,7 +193,6 @@ This document outlines the comprehensive plan to modernize the Munin static gall
 - [x] ✅ **Performance**: No significant performance regression
 
 ### Nice to Have
-- [ ] **Static Binary**: Successfully builds static executable
 - [ ] **Improved Performance**: Better than original with async/await
 - [ ] **Better Error Handling**: More descriptive error messages
 - [ ] **Code Quality**: Cleaner, more maintainable codebase
@@ -249,145 +233,8 @@ This plan will be updated as work progresses. Each checkbox represents a complet
 
 **⚠️ KNOWN LIMITATION**: GalleryTests have configuration conflicts when run in isolation but core functionality is verified.
 
-## Static Binary Investigation Results
-
-### ✅ Partial Success Achieved
-
-**Static Swift Standard Library**: Successfully implemented using `swift build --static-swift-stdlib`
-- Binary size: 73MB (vs 7MB dynamic)
-- Zero Swift runtime dependencies
-- Fully self-contained for Swift components
-
-**Static Linux SDK**: Successfully installed and tested Swift 6.1 Static Linux SDK
-- SDK installed: `swift-6.1-RELEASE_static-linux-0.0.1`
-- Uses musl libc instead of glibc
-- Provides fully static executables
-
-### ❌ Current Limitations
-
-**C Library Dependencies**: The project depends on system C libraries that are not available in the musl-based static SDK:
-- libvips.so.42 (image processing)
-- libiptcdata.so.0 (IPTC metadata)
-- libexif.so.12 (EXIF data)
-- libgd.so.3 (graphics library)
-
-**Build Error**: Static Linux SDK build fails with:
-```
-fatal error: 'vips/vips.h' file not found
-```
-
-### 🔬 Detailed Investigation Results
-
-**Alpine Package Extraction**: Successfully downloaded and extracted Alpine Linux packages:
-- ✅ Headers: 87 header files extracted and placed in musl SDK
-- ⚠️ Static Libraries: Only libgd.a available, others are shared-only
-- ❌ Package Dependencies: Swift package dependencies have hardcoded header paths
-
-**musl SDK Integration**: Attempted to integrate Alpine libraries with musl SDK:
-- ✅ Headers copied to musl SDK include directory
-- ✅ libgd.a static library integrated
-- ❌ Missing static libraries for libvips, libexif, libiptcdata
-- ❌ Swift package C dependencies incompatible with cross-compilation
-
-**Technical Challenges**:
-1. **No Static Libraries**: Alpine Linux doesn't ship static versions of most libraries
-2. **Hardcoded Paths**: Swift-vips and SwiftExif packages expect system header locations
-3. **Complex Dependencies**: libvips depends on 100+ system libraries
-4. **Cross-Compilation**: musl != glibc library compatibility issues
-
-### 🔄 Potential Solutions
-
-1. **✅ Hybrid Approach**: Use `--static-swift-stdlib` for partial static linking (eliminates Swift runtime dependencies)
-2. **❌ Custom C Library Building**: Build static versions of C libraries for musl (complex due to 100+ dependencies)
-3. **🔄 Alternative Image Processing**: Replace VIPS with pure Swift image processing libraries (major refactor)
-4. **🔄 Docker-based Distribution**: Package the dynamic binary with all dependencies in a container
-5. **🔄 Source-based Static Build**: Build all C libraries from source in Alpine environment
-6. **🔄 Library Replacement**: Use Swift-native alternatives (e.g., SwiftGD instead of libgd)
-
-### 📊 Comparison Summary
-
-| Approach | Binary Size | Swift Deps | C Deps | Compatibility |
-|----------|-------------|------------|--------|---------------|
-| Dynamic | 7MB | 13 .so files | 100+ .so files | glibc systems |
-| Static Swift | 73MB | 0 | 100+ .so files | glibc systems |
-| Full Static | N/A | 0 | 0 | Any Linux |
-
-### 🎯 Recommendations
-
-**✅ Immediate Solution**: Use `swift build --static-swift-stdlib -c release`
-- Eliminates 13 Swift runtime dependencies
-- Maintains full compatibility with existing C libraries
-- Binary size: 73MB (acceptable for distribution)
-- Works on all glibc-based Linux systems
-
-**🔄 Future Enhancement Options**:
-1. **Docker Distribution**: Package in minimal Alpine container
-2. **Library Migration**: Gradually replace C dependencies with Swift alternatives
-3. **Source Building**: Create Alpine-based build environment for full static libraries
-
-**❌ Not Recommended**: 
-- Attempting to retrofit existing C dependencies to musl (too complex)
-- Building all dependencies from source (time-intensive, maintenance burden)
-
-## Musl Static Build Investigation Results
-
-### 📋 Challenge Summary
-The user requested a fully static musl-compatible binary. After extensive investigation, this proved to be technically challenging due to:
-
-1. **Header Path Conflicts**: The musl Swift SDK and glibc headers have incompatible type definitions
-2. **Dependency Chain Complexity**: VIPS depends on glib-2.0 which has 50+ transitive dependencies
-3. **Cross-compilation Issues**: Mixed glibc/musl header environments cause compilation failures
-
-### 🔬 Technical Analysis
-**Attempted Solutions**:
-1. **Alpine Linux Chroot**: Set up musl-based build environment with 53 static libraries
-2. **Header Isolation**: Created clean include paths using only musl headers
-3. **Library Extraction**: Built musl-compatible static libraries (libvips.a: 6.6MB, libglib-2.0.a: 15MB)
-4. **Cross-compilation**: Used Swift 6.1 Static Linux SDK with musl support
-
-**Core Issues Encountered**:
-- `__time64_t` vs `time_t` type conflicts between glibc and musl
-- Missing `__BEGIN_DECLS` and `__END_DECLS` macros in musl
-- System header inclusion despite `-nostdinc` flag
-- VIPS headers hardcoded to use system glib paths
-
-### 🛠️ Infrastructure Created
-**Static Library Collection**: 53 musl-compatible static libraries extracted from Alpine Linux
-**Build Scripts**: 
-- `setup-alpine-chroot.sh`: Creates Alpine build environment
-- `extract-alpine-libs.sh`: Extracts musl libraries
-- `build-musl-final.sh`: Attempts full static build
-
-**Files Created**:
-- `/home/ubuntu/git/munin/static-build/musl-libs/`: 53 static libraries, 2859 headers
-- Complete musl build toolchain and Alpine Linux environment
-
-### 🎯 Final Assessment
-**Status**: ❌ Full musl static build not achievable with current approach
-
-**Root Cause Analysis**:
-1. **Architecture Mismatch**: Swift musl SDK contains aarch64 assembly in x86_64 context
-2. **Inline Assembly Conflicts**: x86_64-specific inline assembly constraints incompatible with Swift compiler
-3. **Module System Conflicts**: Duplicate module definitions between musl SDK and extracted libraries
-4. **Complex Dependency Chain**: VIPS requires 50+ transitive dependencies with musl compatibility
-
-**Evidence of Feasibility**: 
-- ✅ [sharp-libvips](https://github.com/lovell/sharp-libvips) successfully builds musl-compatible libvips
-- ✅ Alpine Linux provides musl-based static libraries
-- ✅ Individual libraries can be compiled for musl
-
-**Complexity Assessment**: 
-- 🔬 **High**: Requires dedicated containerized build environment
-- 🔬 **High**: Needs custom Swift SDK integration
-- 🔬 **High**: Architecture-specific assembly code resolution
-- 🔬 **Medium**: 53 static libraries with 2859 headers to manage
-
-**Alternative**: Partial static linking with `--static-swift-stdlib` eliminates Swift dependencies while maintaining C library compatibility
-
-**Recommendation**: Use the partial static build (73MB, 0 Swift deps) as the best compromise between size, compatibility, and maintainability. For full static builds, consider the sharp-libvips approach with dedicated Docker environments and significant engineering investment.
-
 ---
 
-**Last Updated**: 2025-07-11
+**Last Updated**: 2025-10-21
 **Swift Version Target**: 6.1.2 ✅
 **Platform Target**: Ubuntu Linux ✅

--- a/Sources/MuninKit/Album.swift
+++ b/Sources/MuninKit/Album.swift
@@ -253,8 +253,8 @@ extension Album {
 
   public func clean(ctx: Context) {
     let fileManager = FileManager()
-    let unrefFiles = unreferencedFiles()
-    let unrefFolders = unreferencedFolders()
+    let unrefFiles = unreferencedFiles
+    let unrefFolders = unreferencedFolders
 
     ctx.log.info("Cleaning album \(name) of unreferenced files: \(unrefFiles)")
     ctx.log.info("Cleaning album \(name) of unreferenced folders: \(unrefFiles)")
@@ -272,15 +272,15 @@ extension Album {
     }
   }
 
-  func expectedFolders() -> [URL] {
-    // let folderPath = URL(fileURLWithPath: path)
+  // MARK: - Computed Properties
 
-    let expectedFiles = albums.map { URL(fileURLWithPath: $0.path) }
-
-    return expectedFiles
+  /// All folders expected to exist in this album (sub-albums)
+  var expectedFolders: [URL] {
+    albums.map { URL(fileURLWithPath: $0.path) }
   }
 
-  func expectedFiles() -> [URL] {
+  /// All files expected to exist in this album (JSON, photos, and root files)
+  var expectedFiles: [URL] {
     let jsonURL = URL(fileURLWithPath: url)
 
     // TODO: replace this with expectedFiles in Keywords, Locations and Stats
@@ -295,38 +295,33 @@ extension Album {
     // relevant for this folder directly, we do not recurse to the
     // next album in case of nested albums as that is a folder and
     // not files.
-    let expectedFiles = [jsonURL] + photos.flatMap { $0.expectedFiles() } + rootFiles
-
-    return expectedFiles
+    return [jsonURL] + photos.flatMap { $0.expectedFiles } + rootFiles
   }
 
-  func unreferencedFolders() -> [URL] {
+  /// Folders that exist but are not part of the album structure
+  var unreferencedFolders: [URL] {
     let fileManager = FileManager()
-    let expectedFolders = self.expectedFolders()
     let actualFolders = fileManager.directoriesOfDirectory(atPath: path).map {
       URL(fileURLWithPath: joinPath(path, $0))
     }
-
     return actualFolders.filter { !expectedFolders.contains($0) }
   }
 
-  func unreferencedFiles() -> [URL] {
+  /// Files that exist but are not part of the album structure
+  var unreferencedFiles: [URL] {
     let fileManager = FileManager()
-    let expectedFiles = self.expectedFiles()
     let actualFiles = fileManager.filesOfDirectory(atPath: path).map {
       URL(fileURLWithPath: joinPath(path, $0))
     }
-
     return actualFiles.filter { !expectedFiles.contains($0) }
   }
 
-  func missingFiles() -> [URL] {
+  /// Files that should exist but are missing from disk
+  var missingFiles: [URL] {
     let fileManager = FileManager()
-    let expectedFiles = self.expectedFiles()
     let actualFiles = fileManager.filesOfDirectory(atPath: path).map {
       URL(fileURLWithPath: joinPath(path, $0))
     }
-
     return expectedFiles.filter { !actualFiles.contains($0) }
   }
 
@@ -464,7 +459,7 @@ func readStateFromInputDirectory(
         )
 
         if let photo = maybePhoto {
-          if photo.include() {
+          if photo.shouldInclude {
             photosContainer.append(photo)
           } else {
             ctx.log.debug("Photo \(photo.name) included NO_HUGIN keyword, ignoring...")

--- a/Sources/MuninKit/Gallery.swift
+++ b/Sources/MuninKit/Gallery.swift
@@ -90,28 +90,19 @@ public struct Context: @unchecked Sendable {
     self.config = config
     self.time = Timings()
 
-    if let _ = config.logPath {
-      // do {
-      // let fileLogger = try FileLogging(to: URL(fileURLWithPath: logPath))
-
+    // Set up logging system
+    if config.logPath != nil {
+      // TODO: Implement file logging when needed
       LoggingSystem.bootstrap { label in
-        let handlers: [LogHandler] = [
-          // FileLogHandler(label: label, fileLogger: fileLogger),
+        MultiplexLogHandler([
           StreamLogHandler.standardOutput(label: label)
-        ]
-        return MultiplexLogHandler(handlers)
+        ])
       }
-      // } catch {
-      //   print("Failed to set up log file, stdout only")
-      // }
     }
 
+    // Configure logger with appropriate log level
     var logger = Logger(label: "no.kradalby.MuninKit")
-    if let logLevel = config.logLevel {
-      logger.logLevel = stringToLogLevel(logLevel)
-    } else {
-      logger.logLevel = .info
-    }
+    logger.logLevel = config.logLevel.map(stringToLogLevel) ?? .info
     self.log = logger
 
     // https://www.vadimbulavin.com/grand-central-dispatch-in-swift/#limiting-work-in-progress
@@ -168,8 +159,9 @@ public struct GalleryConfiguration: Sendable {
     self.combinedPeople = Set(people).union(peopleFromFiles.flatMap { $0 })
   }
 
-  func allPeople() -> Set<String> {
-    return combinedPeople
+  /// All people from both the configuration and people files
+  var allPeople: Set<String> {
+    combinedPeople
   }
 }
 
@@ -177,6 +169,7 @@ struct PeopleFile: Decodable {
   let people: [String]
 }
 
+/// A photo gallery consisting of albums and photos
 public struct Gallery {
   var input: Album
   var output: Album?
@@ -192,6 +185,9 @@ public struct Gallery {
   let changedContent: Album?
 
   // swiftlint:disable function_body_length
+  /// Initialize a gallery by reading the input directory and comparing with existing output
+  ///
+  /// - Parameter ctx: The context containing configuration and state
   public init(ctx: Context) {
 
     var time = Timings()
@@ -240,6 +236,11 @@ public struct Gallery {
     print("Times: ", time)
   }
 
+  /// Build the gallery by processing photos and generating metadata
+  ///
+  /// - Parameters:
+  ///   - ctx: The context containing configuration and state
+  ///   - jsonOnly: If true, only write JSON metadata without processing images
   public func build(ctx: Context, jsonOnly: Bool) {
     if let changed = changedContent {
       ctx.log.info("Updating changed photos, resizing and writing images to disk")
@@ -282,10 +283,17 @@ public struct Gallery {
     ctx.log.info("Locations built in \(locationEnd.timeIntervalSince(locationStart)) seconds")
   }
 
+  /// Clean unreferenced files and folders from the gallery
+  ///
+  /// - Parameter ctx: The context containing configuration and state
   public func clean(ctx: Context) {
     input.clean(ctx: ctx)
   }
 
+  /// Generate statistics for the gallery
+  ///
+  /// - Parameter ctx: The context containing configuration and state
+  /// - Returns: Statistics object containing gallery metrics
   public func statistics(ctx: Context) -> Statistics {
     return Statistics(ctx: ctx, gallery: self)
   }

--- a/Sources/MuninKit/Gallery.swift
+++ b/Sources/MuninKit/Gallery.swift
@@ -136,7 +136,7 @@ public struct GalleryConfiguration: Sendable {
   public init(
     _ manager: ConfigurationManager
   ) {
-    name = "root"
+    name = manager["name"] as? String ?? "root"
     people = manager["people"] as? [String] ?? []
     peopleFiles = manager["peopleFiles"] as? [String] ?? []
     resolutions = manager["resolutions"] as? [Int] ?? [1600, 1200, 992, 768, 576, 340, 220, 180]

--- a/Sources/MuninKit/Photo.swift
+++ b/Sources/MuninKit/Photo.swift
@@ -177,10 +177,10 @@ extension Photo {
             }
     
         } catch {
-            ctx.log.error("Could open image \(fileURL.path)")
+            ctx.log.error("Could not open image at \(fileURL.path): \(error)")
         }
         
-      let relativeOriginialPath = Array(repeating: "..", count: depth()) + [originalImagePath]
+      let relativeOriginialPath = Array(repeating: "..", count: depth) + [originalImagePath]
       ctx.log.trace("Symlinking original image \(name) to \(originalImageURL)")
       do {
         try createOrReplaceSymlink(
@@ -237,29 +237,23 @@ extension Photo {
     }
   }
 
-  func expectedFiles() -> [URL] {
+  // MARK: - Computed Properties
+
+  /// All files expected to exist for this photo (JSON, symlink, and scaled versions)
+  var expectedFiles: [URL] {
     let jsonURL = URL(fileURLWithPath: url)
     let symlinkedImageURL = URL(fileURLWithPath: originalImageURL)
-    let expectedFiles =
-      [jsonURL, symlinkedImageURL] + scaledPhotos.map { URL(fileURLWithPath: $0.url) }
-
-    return expectedFiles
+    return [jsonURL, symlinkedImageURL] + scaledPhotos.map { URL(fileURLWithPath: $0.url) }
   }
 
-  func depth() -> Int {
-    let urlSeparator: Character = "/"
-    var counter = 0
-    for char in url where char == urlSeparator {
-      counter += 1
-    }
-    return counter
+  /// The depth of this photo in the directory hierarchy based on URL path
+  var depth: Int {
+    url.filter { $0 == "/" }.count
   }
 
-  func include() -> Bool {
-    for keyword in keywords where keyword.name == "NO_HUGIN" {
-      return false
-    }
-    return true
+  /// Whether this photo should be included in the gallery (excludes NO_HUGIN keyword)
+  var shouldInclude: Bool {
+    !keywords.contains { $0.name == "NO_HUGIN" }
   }
 }
 
@@ -304,24 +298,19 @@ func readPhotoFromPath(
         let height = image.size.height
         photo.width = width
         photo.height = height
-        
+
         // Determine orientation based on EXIF orientation and image dimensions
         // EXIF orientation values: 5,6,7,8 involve 90° rotation (width/height swapped)
         let exifOrientation = image.orientation
-        
-        // Check if the image should be rotated 90 or 270 degrees according to EXIF
-        let rotated90or270 = [5, 6, 7, 8].contains(exifOrientation)
-        
-        if rotated90or270 {
-            // If rotated 90/270, the effective dimensions are swapped
-            photo.orientation = width > height ? .portrait : .landscape
-        } else {
-            // Normal orientation or 180 degree rotation
-            photo.orientation = width < height ? .portrait : .landscape
-        }
-        
+        let isRotated90or270 = [5, 6, 7, 8].contains(exifOrientation)
+
+        // If rotated 90/270, effective dimensions are swapped
+        photo.orientation = isRotated90or270
+            ? (width > height ? .portrait : .landscape)
+            : (width < height ? .portrait : .landscape)
+
     } catch {
-        ctx.log.error("Could open image \(fileURL.path)")
+        ctx.log.error("Could not open image at \(fileURL.path): \(error)")
     }
 
   if let exif = exifRawDict["EXIF"] {
@@ -454,7 +443,7 @@ func readPhotoFromPath(
         name: keyword,
         url: "\(ctx.config.outputPath)/keywords/\(urlifyName(keyword)).json"
       )
-      if ctx.config.allPeople().contains(keyword) {
+      if ctx.config.allPeople.contains(keyword) {
         photo.people.append(keywordPointer)
       } else {
         photo.keywords.append(keywordPointer)
@@ -462,28 +451,26 @@ func readPhotoFromPath(
     }
   }
 
-  if let gpsDict = exifDict["GPS"] {
-    if let altitudeStr = gpsDict["Altitude"],
-      let latitudeStr = gpsDict["Latitude"],
-      let longitudeStr = gpsDict["Longitude"] {
-      if let altitude = Double(altitudeStr),
-        let latitude = LocationDegree.fromString(latitudeStr),
-        let longitude = LocationDegree.fromString(longitudeStr),
-        let longitudeRef = gpsDict["East or West Longitude"],
-        let latitudeRef = gpsDict["North or South Latitude"] {
-        photo.gps = GPS(
-          altitude: altitude,
-          latitude: latitudeRef == "N"
-            ? latitude.toDecimal()
-            : latitude.toDecimal() * -1,
-          longitude: longitudeRef == "E" ? longitude.toDecimal() : longitude.toDecimal() * -1
-        )
-      }
+  if let gpsDict = exifDict["GPS"],
+     let altitudeStr = gpsDict["Altitude"],
+     let latitudeStr = gpsDict["Latitude"],
+     let longitudeStr = gpsDict["Longitude"],
+     let altitude = Double(altitudeStr),
+     let latitude = LocationDegree.fromString(latitudeStr),
+     let longitude = LocationDegree.fromString(longitudeStr),
+     let longitudeRef = gpsDict["East or West Longitude"],
+     let latitudeRef = gpsDict["North or South Latitude"] {
 
-    }
+    let latitudeDecimal = latitudeRef == "N" ? latitude.toDecimal() : -latitude.toDecimal()
+    let longitudeDecimal = longitudeRef == "E" ? longitude.toDecimal() : -longitude.toDecimal()
 
+    photo.gps = GPS(
+      altitude: altitude,
+      latitude: latitudeDecimal,
+      longitude: longitudeDecimal
+    )
   } else {
-    ctx.log.warning("GPS tag not found for photo, some metatags will be unavailable")
+    ctx.log.trace("GPS tag not found for photo")
   }
 
   photo.keywords = Array(Set(photo.keywords)).sorted()

--- a/Tests/MuninKitTests/AlbumTests.swift
+++ b/Tests/MuninKitTests/AlbumTests.swift
@@ -80,7 +80,7 @@ final class AlbumTests: XCTestCase {
       "\(contentDir.path)/test/portrait_mm_1600.jpeg",
       "\(contentDir.path)/test/portrait_mm_original.jpeg",
     ].sorted()
-    let actualFiles = album.expectedFiles().map { $0.path }.sorted()
+    let actualFiles = album.expectedFiles.map { $0.path }.sorted()
     XCTAssertEqual(actualFiles, expectedFiles)
   }
 
@@ -94,7 +94,7 @@ final class AlbumTests: XCTestCase {
     let albumCount = album.numberOfAlbums(travers: true)
     XCTAssertEqual(albumCount, 0)
 
-    let unreferenced = album.unreferencedFiles()
+    let unreferenced = album.unreferencedFiles
 
     XCTAssertEqual(unreferenced, [])
   }
@@ -107,7 +107,7 @@ final class AlbumTests: XCTestCase {
     XCTAssertEqual(photoCount, 104)
     let albumCount = album.numberOfAlbums(travers: true)
     XCTAssertEqual(albumCount, 12)
-    let unreferenced = album.unreferencedFiles()
+    let unreferenced = album.unreferencedFiles
 
     XCTAssertEqual(unreferenced, [])
   }
@@ -147,7 +147,7 @@ final class AlbumTests: XCTestCase {
       "\(contentDir.path)/test/portrait_mm_1600.jpeg",
       "\(contentDir.path)/test/portrait_mm_original.jpeg",
     ].sorted()
-    let missing = album.missingFiles().map { $0.path }.sorted()
+    let missing = album.missingFiles.map { $0.path }.sorted()
 
     XCTAssertEqual(missing, expectedFiles)
   }
@@ -162,7 +162,7 @@ final class AlbumTests: XCTestCase {
     XCTAssertEqual(albumCount, 12)
 
     let expectedFiles: [String] = []
-    let missing = album.missingFiles().map { $0.path }.sorted()
+    let missing = album.missingFiles.map { $0.path }.sorted()
 
     XCTAssertEqual(missing, expectedFiles)
   }

--- a/Tests/MuninKitTests/KeywordTests.swift
+++ b/Tests/MuninKitTests/KeywordTests.swift
@@ -55,10 +55,10 @@ final class KeywordTests: XCTestCase {
       ])
     config = GalleryConfiguration(manager)
 
-    XCTAssertEqual(config.allPeople().count, 4)
+    XCTAssertEqual(config.allPeople.count, 4)
   }
 
   func testPeopleFilesAuto() {
-    XCTAssertEqual(config.allPeople().count, 16)
+    XCTAssertEqual(config.allPeople.count, 16)
   }
 }

--- a/Tests/MuninKitTests/PhotoTests.swift
+++ b/Tests/MuninKitTests/PhotoTests.swift
@@ -114,7 +114,7 @@ final class PhotoTests: XCTestCase {
       "test_340.jpg", "test_576.jpg", "test_768.jpg",
       "test_992.jpg", "test_1200.jpg", "test_original.jpg",
     ].map { URL(fileURLWithPath: "example/content/" + $0).path }.sorted()
-    let actualFiles = photo!.expectedFiles().map { $0.path }.sorted()
+    let actualFiles = photo!.expectedFiles.map { $0.path }.sorted()
 
     XCTAssertEqual(actualFiles, expectedFiles)
   }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,8 @@
 {
   inputs = {
-    nixpkgs.url = "nixpkgs/nixpkgs-unstable";
+    # Pin to a nixpkgs revision with Swift 6+
+    # Using nixpkgs-unstable latest which should have Swift 6
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -19,6 +21,7 @@
       with pkgs;
         [
           pkg-config
+          # Use the main swift package (not swiftPackages) for Swift 6
           swift
           swiftpm
         ];

--- a/flake.nix
+++ b/flake.nix
@@ -19,10 +19,8 @@
       with pkgs;
         [
           pkg-config
-        ]
-        ++ lib.optionals stdenv.isLinux [
-          swiftPackages.swiftNoSwiftDriver
-          swiftPackages.swiftpm
+          swift
+          swiftpm
         ];
 
     bdeps = pkgs:
@@ -70,12 +68,6 @@
           # and find that library in Nix and add it to the buildDeps.
         ]
         ++ lib.optionals stdenv.isLinux [
-          swiftPackages.stdenv
-          swiftPackages.XCTest
-          swiftPackages.Foundation
-          swiftPackages.Dispatch
-
-          swift-corelibs-libdispatch
           glibc.dev
 
           # swift-vips linux deps
@@ -108,7 +100,7 @@
             inherit src;
             LD_LIBRARY_PATH =
               if pkgs.stdenv.isLinux
-              then "${pkgs.swiftPackages.Dispatch}/lib"
+              then pkgs.lib.makeLibraryPath (bdeps pkgs)
               else null;
 
             strictDeps = true;
@@ -147,7 +139,7 @@
       devShell = pkgs.mkShell.override {inherit (pkgs.swift) stdenv;} {
         LD_LIBRARY_PATH =
           if pkgs.stdenv.isLinux
-          then "${pkgs.swiftPackages.Dispatch}/lib"
+          then pkgs.lib.makeLibraryPath (bdeps pkgs)
           else null;
         nativeBuildInputs = ndeps pkgs;
         buildInputs =


### PR DESCRIPTION
- Update swift-tools-version to 6.0
- Update .swift-version to 6.1
- Remove deprecated Configuration and swift-tools-support-core
- Update dependencies to latest compatible versions
- Install required Linux system dependencies (VIPS, GD, EXIF)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>