### PR TITLE
deps: bump kradalby/SwiftExif to 0.1.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1c20c554b87e332678bf9b197f49291f1c1856612c47bc7cdfa08eed3390d236",
+  "originHash" : "379c7b238c9b3cd48d6f19b6d69e9bdb2bd0d735759f7c21f2d13352157531c6",
   "pins" : [
     {
       "identity" : "console-kit",
@@ -104,7 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kradalby/SwiftExif.git",
       "state" : {
-        "revision" : "eb7c5c4e034f0fc01c5a11b3c1d1ac3074f0acb1"
+        "revision" : "313786acd418032640b8f81b0287292c4c688e05",
+        "version" : "0.1.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -35,11 +35,7 @@ let package = Package(
     .package(
       url: "https://github.com/t089/swift-vips.git",
       revision: "d01b393ef30b3a2ae6ed97a02f61edab3d44b4af"),
-    // SwiftExif: upstream tag 0.0.7 predates the Swift 6.3 fix; pin to master
-    // SHA until a new tag is released. Tracked in FUTURES.md.
-    .package(
-      url: "https://github.com/kradalby/SwiftExif.git",
-      revision: "eb7c5c4e034f0fc01c5a11b3c1d1ac3074f0acb1"),
+    .package(url: "https://github.com/kradalby/SwiftExif.git", from: "0.1.0"),
     .package(url: "https://github.com/apple/swift-log.git", from: "1.12.0"),
     // vapor/console-kit provides the progress/activity indicator UI that
     // replaced swift-tools-support-core's PercentProgressAnimation.


### PR DESCRIPTION
SwiftExif tagged 0.1.0 with the Swift 6.3 fix already on master plus a Sendable typed parse API. Drops the SHA pin Munin has been carrying since the fix landed.

Existing dict-returning calls in `Sources/MuninKit/IO/Imaging/EXIF.swift` still build under the deprecated API and now emit warnings. Migrating that file to `Image.parse(at:)` + `ExifResult` (and dropping the `as? String` / `as? [String]` coercions on `IPTCFields`) is a separate follow-up. `FUTURES.md` §4 is briefly stale until that lands.

Generated with the help of an AI assistant